### PR TITLE
Added :host ("ezid.cdlib.org") and :use_ssl (`true`) options to Client config

### DIFF
--- a/lib/ezid/client.rb
+++ b/lib/ezid/client.rb
@@ -1,3 +1,5 @@
+require "uri"
+
 require_relative "configuration"
 require_relative "request"
 require_relative "response"
@@ -28,12 +30,16 @@ module Ezid
       end
     end
 
-    attr_reader :session, :user, :password # , :host
+    attr_reader :session, :user, :password, :host, :use_ssl
 
     def initialize(opts = {})
       @session = Session.new
+      @host = opts[:host] || config.host
+      @use_ssl = opts.fetch(:use_ssl, config.use_ssl)
       @user = opts[:user] || config.user
+      raise Error, "User name is required." unless user
       @password = opts[:password] || config.password
+      raise Error, "Password is required." unless password
       if block_given?
         login
         yield self
@@ -42,7 +48,7 @@ module Ezid
     end
 
     def inspect
-      "#<#{self.class.name} user=\"#{user}\" session=#{logged_in? ? 'OPEN' : 'CLOSED'}>"
+      "#<#{self.class.name} host=\"#{host}\" user=\"#{user}\" session=#{logged_in? ? 'OPEN' : 'CLOSED'}>"
     end
 
     # The client configuration
@@ -64,7 +70,7 @@ module Ezid
       if logged_in?
         logger.info("Already logged in, skipping login request.")
       else
-        response = Request.execute(:Get, "/login") do |request|
+        response = Request.execute(:Get, build_uri("/login")) do |request|
           add_authentication(request)
         end
         handle_response(response, "LOGIN")
@@ -77,7 +83,7 @@ module Ezid
     # @return [Ezid::Client] the client
     def logout
       if logged_in?
-        response = Request.execute(:Get, "/logout")
+        response = Request.execute(:Get, build_uri("/logout"))
         handle_response(response, "LOGOUT")
         session.close
       else
@@ -96,7 +102,7 @@ module Ezid
     # @raise [Ezid::Error]
     # @return [Ezid::Response] the response
     def create_identifier(identifier, metadata=nil)
-      response = Request.execute(:Put, "/id/#{identifier}") do |request|
+      response = Request.execute(:Put, build_uri("/id/#{identifier}")) do |request|
         add_authentication(request)
         add_metadata(request, metadata)
       end
@@ -110,7 +116,7 @@ module Ezid
     def mint_identifier(shoulder=nil, metadata=nil)
       shoulder ||= config.default_shoulder
       raise Error, "Shoulder missing -- cannot mint identifier." unless shoulder
-      response = Request.execute(:Post, "/shoulder/#{shoulder}") do |request|
+      response = Request.execute(:Post, build_uri("/shoulder/#{shoulder}")) do |request|
         add_authentication(request)
         add_metadata(request, metadata)
       end
@@ -122,7 +128,7 @@ module Ezid
     # @raise [Ezid::Error]
     # @return [Ezid::Response] the response
     def modify_identifier(identifier, metadata)
-      response = Request.execute(:Post, "/id/#{identifier}") do |request|
+      response = Request.execute(:Post, build_uri("/id/#{identifier}")) do |request|
         add_authentication(request)
         add_metadata(request, metadata)
       end
@@ -133,7 +139,7 @@ module Ezid
     # @raise [Ezid::Error]
     # @return [Ezid::Response] the response
     def get_identifier_metadata(identifier)
-      response = Request.execute(:Get, "/id/#{identifier}") do |request|
+      response = Request.execute(:Get, build_uri("/id/#{identifier}")) do |request|
         add_authentication(request)
       end
       handle_response(response, "GET #{identifier}")
@@ -143,7 +149,7 @@ module Ezid
     # @raise [Ezid::Error]
     # @return [Ezid::Response] the response
     def delete_identifier(identifier)
-      response = Request.execute(:Delete, "/id/#{identifier}") do |request|
+      response = Request.execute(:Delete, build_uri("/id/#{identifier}")) do |request|
         add_authentication(request)
       end
       handle_response(response, "DELETE #{identifier}")
@@ -153,11 +159,16 @@ module Ezid
     # @raise [Ezid::Error]
     # @return [Ezid::Status] the status response
     def server_status(*subsystems)
-      response = Request.execute(:Get, "/status?subsystems=#{subsystems.join(',')}")
+      response = Request.execute(:Get, build_uri("/status?subsystems=#{subsystems.join(',')}"))
       handle_response(Status.new(response), "STATUS")
     end
 
     private
+
+      def build_uri(path)
+        scheme = use_ssl ? "https" : "http"
+        URI([scheme, "://", host, path].join)
+      end
 
       # Adds authentication data to the request
       def add_authentication(request)

--- a/lib/ezid/configuration.rb
+++ b/lib/ezid/configuration.rb
@@ -9,6 +9,16 @@ module Ezid
   # @api private
   class Configuration
 
+    HOST = "ezid.cdlib.org"
+
+    # EZID host name
+    #   Default: "ezid.cdlib.org"
+    attr_accessor :host
+
+    # Use HTTPS?
+    #   Default: `true`
+    attr_accessor :use_ssl
+
     # EZID user name
     #   Default: value of `EZID_USER` environment variable
     attr_accessor :user
@@ -38,6 +48,8 @@ module Ezid
     def initialize
       @user = ENV["EZID_USER"]
       @password = ENV["EZID_PASSWORD"]
+      @host = HOST
+      @use_ssl = true
     end
 
     def logger

--- a/lib/ezid/request.rb
+++ b/lib/ezid/request.rb
@@ -10,7 +10,6 @@ module Ezid
   #
   class Request < SimpleDelegator
 
-    HOST = "https://ezid.cdlib.org"
     CHARSET = "UTF-8"
     CONTENT_TYPE = "text/plain"
 
@@ -21,10 +20,9 @@ module Ezid
     end
 
     # @param method [Symbol] the Net::HTTP constant for the request method
-    # @param path [String] the uri path (including query string, if any)
-    def initialize(method, path)
+    # @param uri [URI] the uri 
+    def initialize(method, uri) # path)
       http_method = Net::HTTP.const_get(method)
-      uri = URI.parse([HOST, path].join)
       super(http_method.new(uri))
       set_content_type(CONTENT_TYPE, charset: CHARSET)
     end
@@ -32,10 +30,14 @@ module Ezid
     # Executes the request and returns the response
     # @return [Ezid::Response] the response
     def execute
-      http_response = Net::HTTP.start(uri.host, use_ssl: true) do |http|
+      http_response = Net::HTTP.start(uri.host, use_ssl: use_ssl?) do |http|
         http.request(__getobj__)
       end
       Response.new(http_response)
+    end
+
+    def use_ssl?
+      uri.is_a?(URI::HTTPS)
     end
 
   end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -1,6 +1,9 @@
 module Ezid
   RSpec.describe Client do
 
+    let(:stub_response) { Response.new(http_response) }
+    let(:stub_uri) { double }
+
     describe "initialization without a block" do
       it "should not login" do
         expect_any_instance_of(described_class).not_to receive(:login)
@@ -11,30 +14,34 @@ module Ezid
     describe "#create_identifier" do
       let(:id) { "ark:/99999/fk4fn19h88" }
       let(:http_response) { double(body: "success: ark:/99999/fk4fn19h88") }
-      let(:stub_response) { Response.new(http_response) }
       before do
-        allow(Request).to receive(:execute) { stub_response }
+        allow(subject).to receive(:build_uri).with("/id/#{id}") { stub_uri }
+        allow(Request).to receive(:execute).with(:Put, stub_uri) { stub_response }
       end
-      subject { described_class.new.create_identifier(id) }
       it "should be a success" do
-        expect(subject).to be_success
-        expect(subject.id).to eq(id)
+        response = subject.create_identifier(id)
+        expect(response).to be_success
+        expect(response.id).to eq(id)
       end
     end
 
     describe "#mint_identifier" do
+      before do
+        allow(Request).to receive(:execute).with(:Post, stub_uri) { stub_response }
+      end
       describe "which is an ARK" do
-        let(:stub_response) { Response.new(double(body: "success: ark:/99999/fk4fn19h88")) }
-        before { allow(Request).to receive(:execute).with(:Post, "/shoulder/#{TEST_ARK_SHOULDER}") { stub_response } }
-        subject { described_class.new.mint_identifier(TEST_ARK_SHOULDER) }
-        it "should be a succes" do
-          expect(subject).to be_success
-          expect(subject.id).to eq("ark:/99999/fk4fn19h88")
+        let(:http_response) { double(body: "success: ark:/99999/fk4fn19h88") }
+        before do
+          allow(subject).to receive(:build_uri).with("/shoulder/#{TEST_ARK_SHOULDER}") { stub_uri }
+        end
+        it "should be a success" do
+          response = subject.mint_identifier(TEST_ARK_SHOULDER)
+          expect(response).to be_success
+          expect(response.id).to eq("ark:/99999/fk4fn19h88")
         end
       end
       describe "which is a DOI" do
         let(:http_response) { double(body: "success: doi:10.5072/FK2TEST | ark:/99999/fk4fn19h88") }
-        let(:stub_response) { Response.new(http_response) }
         let(:metadata) do
           <<-EOS
 datacite.title: Test
@@ -44,38 +51,41 @@ datacite.publicationyear: 2014
 datacite.resourcetype: Other
 EOS
         end
-        before { allow(Request).to receive(:execute).with(:Post, "/shoulder/#{TEST_DOI_SHOULDER}") { stub_response } }
-        subject { described_class.new.mint_identifier(TEST_DOI_SHOULDER, metadata) }
+        before do
+          allow(subject).to receive(:build_uri).with("/shoulder/#{TEST_DOI_SHOULDER}") { stub_uri }
+        end
         it "should be a sucess" do
-          expect(subject).to be_success
-          expect(subject.id).to eq("doi:10.5072/FK2TEST")
-          expect(subject.shadow_ark).to eq("ark:/99999/fk4fn19h88")
+          response = subject.mint_identifier(TEST_DOI_SHOULDER, metadata)
+          expect(response).to be_success
+          expect(response.id).to eq("doi:10.5072/FK2TEST")
+          expect(response.shadow_ark).to eq("ark:/99999/fk4fn19h88")
         end
       end
       describe "when a shoulder is not given" do
-        let(:stub_response) { Response.new(double(body: "success: ark:/99999/fk4fn19h88")) }
+        let(:http_response) { double(body: "success: ark:/99999/fk4fn19h88") }
         context "and the :default_shoulder config option is set" do
-          subject { described_class.new.mint_identifier }
           before do
-            allow(Request).to receive(:execute).with(:Post, "/shoulder/#{TEST_ARK_SHOULDER}") { stub_response }
+            allow(subject).to receive(:build_uri).with("/shoulder/#{TEST_ARK_SHOULDER}") { stub_uri }
             allow(Client.config).to receive(:default_shoulder) { TEST_ARK_SHOULDER }
           end
           it "should use the default shoulder" do
-            expect(subject).to be_success
+            response = subject.mint_identifier
+            expect(response).to be_success
           end
         end
         context "and the :default_shoulder config option is not set" do
           before { allow(Client.config).to receive(:default_shoulder) { nil } }
           it "should raise an exception" do
-            expect { described_class.new.mint_identifier }.to raise_error
+            expect { subject.mint_identifier }.to raise_error
           end
         end
       end
     end
 
     describe "#get_identifier_metadata" do
-      let(:stub_response) do
-        Response.new(double(body: <<-EOS
+      let(:id) { "ark:/99999/fk4fn19h88" }
+      let(:http_response) do
+        double(body: <<-EOS
 success: ark:/99999/fk4fn19h88
 _updated: 1416507086
 _target: http://ezid.cdlib.org/id/ark:/99999/fk4fn19h88
@@ -86,14 +96,16 @@ _export: yes
 _created: 1416507086
 _status: public
 EOS
-                                     ))
+                                     )
       end
       before do
-        allow(Request).to receive(:execute) { stub_response }
+        allow(subject).to receive(:build_uri).with("/id/#{id}") { stub_uri }
+        allow(Request).to receive(:execute).with(:Get, stub_uri) { stub_response }
       end
-      subject { described_class.new.get_identifier_metadata("ark:/99999/fk4fn19h88") }
       it "should retrieve the metadata" do
-        expect(subject.metadata).to eq <<-EOS
+        response = subject.get_identifier_metadata(id)
+        expect(response).to be_success
+        expect(response.metadata).to eq <<-EOS
 _updated: 1416507086
 _target: http://ezid.cdlib.org/id/ark:/99999/fk4fn19h88
 _profile: erc
@@ -115,26 +127,23 @@ ldap: up
 EOS
                )
       end
-      let(:stub_response) { Response.new(http_response) }
       before do
-        allow(Request).to receive(:execute) { stub_response }
+        allow(subject).to receive(:build_uri).with("/status?subsystems=*") { stub_uri }
+        allow(Request).to receive(:execute).with(:Get, stub_uri) { stub_response }
       end
-      subject { described_class.new.server_status("*") }
       it "should report the status of EZID and subsystems" do
-        expect(subject).to be_success
-        expect(subject).to be_up
-        expect(subject.message).to eq("EZID is up")
-        expect(subject.noid).to eq("up")
-        expect(subject.ldap).to eq("up")
-        expect(subject.datacite).to eq("not checked")
+        response = subject.server_status("*")
+        expect(response).to be_success
+        expect(response).to be_up
+        expect(response.message).to eq("EZID is up")
+        expect(response.noid).to eq("up")
+        expect(response.ldap).to eq("up")
+        expect(response.datacite).to eq("not checked")
       end
     end
 
     describe "error handling" do
-      let(:stub_response) { Response.new(body: "error: bad request - no such identifier") }
-      before do
-        allow(Request).to receive(:execute) { stub_response }
-      end
+      let(:http_response) { double(body: "error: bad request - no such identifier") }
       it "should raise an exception" do
         expect { subject.get_identifier_metadata("invalid") }.to raise_error
       end


### PR DESCRIPTION
Private API between Client and Request tweaked to maintain separation (i.e, so
that Request does not need access to Client): Request initializes with a full
URI rather than just a path.
Closes #15
