### PR TITLE
Test environment variables

### DIFF
--- a/lib/ezid/test_helper.rb
+++ b/lib/ezid/test_helper.rb
@@ -5,18 +5,19 @@ module Ezid
 
     TEST_ARK_SHOULDER = "ark:/99999/fk4"
     TEST_DOI_SHOULDER = "doi:10.5072/FK2"
+
     TEST_USER = "apitest"
     TEST_HOST = Configuration::HOST
+    TEST_SHOULDER = TEST_ARK_SHOULDER
 
     def ezid_test_mode!
       Ezid::Client.configure do |config|
-        config.user = TEST_USER
-        # Contact EZID for password, or use your own user name and password
-        # config.password = "********"
-        config.host = TEST_HOST
-        config.use_ssl = true
-        config.logger = Logger.new(File::NULL)
-        config.default_shoulder = TEST_ARK_SHOULDER
+        config.user     = ENV["EZID_TEST_USER"] || TEST_USER
+        config.password = ENV["EZID_TEST_PASSWORD"]
+        config.host     = ENV["EZID_TEST_HOST"] || TEST_HOST
+        config.use_ssl  = true
+        config.logger   = Logger.new(File::NULL)
+        config.default_shoulder = ENV["EZID_TEST_SHOULDER"] || TEST_SHOULDER
       end
     end
 


### PR DESCRIPTION
Ezid::TestHelper#ezid_test_mode! now uses `EZID_TEST_USER`, `EZID_TEST_PASSWORD`,
`EZID_TEST_HOST` and `EZID_TEST_SHOULDER` env vars if set.
