### PR TITLE
Metadata element accessors are no longer explicitly defined;

### DIFF
--- a/lib/ezid/configuration.rb
+++ b/lib/ezid/configuration.rb
@@ -54,5 +54,9 @@ module Ezid
       Identifier
     end
 
+    def metadata
+      Metadata
+    end
+
   end
 end

--- a/lib/ezid/identifier.rb
+++ b/lib/ezid/identifier.rb
@@ -1,19 +1,15 @@
-require "forwardable"
-
 module Ezid
   #
   # Represents an EZID identifier as a resource.
   #
+  # Ezid::Identifier delegates access to registered metadata elements through #method_missing.
+  #
   # @api public
   #
   class Identifier
-    extend Forwardable
 
     attr_reader :id, :client
     attr_accessor :shoulder, :metadata
-
-    def_delegators :metadata, *(Metadata.elements.readers)
-    def_delegators :metadata, *(Metadata.elements.writers)
 
     # Attributes to display on inspect
     INSPECT_ATTRS = %w( id status target created )
@@ -176,37 +172,46 @@ module Ezid
       self.status = PUBLIC
     end
 
+    protected
+
+      def method_missing(method, *args)
+        metadata.send(method, *args)
+      rescue NoMethodError
+        super
+      end
+
     private
 
-    def refresh_metadata
-      response = client.get_identifier_metadata(id)
-      @metadata = Metadata.new(response.metadata)
-    end
+      def refresh_metadata
+        response = client.get_identifier_metadata(id)
+        @metadata = Metadata.new(response.metadata)
+      end
 
-    def clear_metadata
-      @metadata.clear
-    end
+      def clear_metadata
+        @metadata.clear
+      end
 
-    def modify
-      client.modify_identifier(id, metadata)
-    end
+      def modify
+        client.modify_identifier(id, metadata)
+      end
 
-    def create_or_mint
-      id ? create : mint
-    end
+      def create_or_mint
+        id ? create : mint
+      end
 
-    def mint
-      response = client.mint_identifier(shoulder, metadata)
-      @id = response.id
-    end
+      def mint
+        response = client.mint_identifier(shoulder, metadata)
+        @id = response.id
+      end
 
-    def create
-      client.create_identifier(id, metadata)
-    end
+      def create
+        client.create_identifier(id, metadata)
+      end
 
-    def init_metadata(args)
-      @metadata = Metadata.new(args.delete(:metadata))
-      update_metadata(self.class.defaults.merge(args))
-    end
+      def init_metadata(args)
+        @metadata = Metadata.new(args.delete(:metadata))
+        update_metadata(self.class.defaults.merge(args))
+      end
+
   end
 end

--- a/spec/unit/identifier_spec.rb
+++ b/spec/unit/identifier_spec.rb
@@ -108,7 +108,7 @@ module Ezid
       context "when id and `created' are present" do
         before do
           allow(subject).to receive(:id) { "ark:/99999/fk4fn19h88" }
-          allow(subject.metadata).to receive(:created) { Time.at(1416507086) }
+          subject.metadata["_created"] = "1416507086"
         end
         it "should be true" do
           expect(subject).to be_persisted
@@ -185,26 +185,26 @@ module Ezid
 
     describe "boolean status methods" do
       context "when the identifier is public" do
-        before { allow(subject.metadata).to receive(:status) { Identifier::PUBLIC } }
+        before { subject.public! }
         it { is_expected.to be_public }
         it { is_expected.not_to be_reserved }
         it { is_expected.not_to be_unavailable }
       end
       context "when the identifier is reserved" do
-        before { allow(subject.metadata).to receive(:status) { Identifier::RESERVED } }
+        before { subject.status = Identifier::RESERVED }
         it { is_expected.not_to be_public }
         it { is_expected.to be_reserved }
         it { is_expected.not_to be_unavailable }
       end
       context "when the identifier is unavailable" do
         context "and it has no reason" do
-          before { allow(subject.metadata).to receive(:status) { Identifier::UNAVAILABLE } }
+          before { subject.unavailable! }
           it { is_expected.not_to be_public }
           it { is_expected.not_to be_reserved }
           it { is_expected.to be_unavailable }
         end
         context "and it has a reason" do
-          before { allow(subject.metadata).to receive(:status) { "#{Identifier::UNAVAILABLE} | withdrawn" } }
+          before { subject.unavailable!("withdrawn") }
           it { is_expected.not_to be_public }
           it { is_expected.not_to be_reserved }
           it { is_expected.to be_unavailable }

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -33,6 +33,7 @@ module Ezid
         end
       end
     end
+
     describe "metadata profiles" do
       Metadata::PROFILES.each do |profile, elements|
         describe "the '#{profile}' metadata profile" do
@@ -62,6 +63,22 @@ module Ezid
             subject.send("#{profile}=", "value")
           end
         end
+      end
+    end
+
+    describe "custom element" do
+      let(:element) { Metadata::Element.new("custom", true) }
+      before do
+        allow(subject.registered_elements).to receive(:include?).with(:custom) { true } 
+        allow(subject.registered_elements).to receive(:[]).with(:custom) { element } 
+      end
+      it "should have a reader" do
+        expect(subject).to receive(:reader).with("custom")
+        subject.custom
+      end
+      it "should have a writer" do
+        expect(subject).to receive(:writer).with("custom", "value")
+        subject.custom = "value"
       end
     end
 


### PR DESCRIPTION
instead the element registry is used through #method_missing.
Custom element accessors can be registered (closes #13, closes #25).
