### PR TITLE
Ezid::Metadata.register_element defines reader and writer methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ I, [2014-12-04T15:12:48.853964 #86734]  INFO -- : EZID DELETE ark:/99999/fk4n58p
 
 ## Metadata handling
 
-In order to ease metadata management access to EZID [reserved metadata elements](http://ezid.cdlib.org/doc/apidoc.html#internal-metadata) and [metadata profiles](http://ezid.cdlib.org/doc/apidoc.html#metadata-profiles) is provided through `#method_missing` according to these heuristics:
+Accessors are provided to ease the use of EZID [reserved metadata elements](http://ezid.cdlib.org/doc/apidoc.html#internal-metadata) and [metadata profiles](http://ezid.cdlib.org/doc/apidoc.html#metadata-profiles):
 
 **Reserved elements** can be read and written using the name of the element without the leading underscore:
 

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -68,10 +68,8 @@ module Ezid
 
     describe "custom element" do
       let(:element) { Metadata::Element.new("custom", true) }
-      before do
-        allow(subject.registered_elements).to receive(:include?).with(:custom) { true } 
-        allow(subject.registered_elements).to receive(:[]).with(:custom) { element } 
-      end
+      before { described_class.register_element :custom }
+      after { described_class.send(:unregister_element, :custom) }
       it "should have a reader" do
         expect(subject).to receive(:reader).with("custom")
         subject.custom


### PR DESCRIPTION
(instead of relying on #method_missing).
Added Ezid::Metadata.unregister_element private class method,
mainly to support testing.
