### PR TITLE
Identifier metadata is now loaded lazily from EZID

### DIFF
--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -195,15 +195,15 @@ _status: public
 EOS
         end
         it "should treat the string as an ANVL document, splitting into keys and values and unescaping" do
-          expect(subject).to eq({ "_updated" => "1416507086",
-                                  "_target" => "http://example.com/path%20with%20spaces",
-                                  "_profile" => "erc",
-                                  "_erc" => "who: Proust, Marcel\nwhat: Remembrance of Things Past",
-                                  "_ownergroup" => "apitest",
-                                  "_owner" => "apitest",
-                                  "_export" => "yes",
-                                  "_created" => "1416507086",
-                                  "_status" => "public" })
+          expect(subject.elements).to eq({ "_updated" => "1416507086",
+                                           "_target" => "http://example.com/path%20with%20spaces",
+                                           "_profile" => "erc",
+                                           "_erc" => "who: Proust, Marcel\nwhat: Remembrance of Things Past",
+                                           "_ownergroup" => "apitest",
+                                           "_owner" => "apitest",
+                                           "_export" => "yes",
+                                           "_created" => "1416507086",
+                                           "_status" => "public" })
         end
       end
       context "of a hash-like object" do
@@ -219,14 +219,14 @@ EOS
         end
         context "which is a normal Hash" do
           let(:data) { hsh }
-          it "should set the metadata to the hash" do
-            expect(subject).to eq(hsh)
+          it "should set the metadata elements to the hash" do
+            expect(subject.elements).to eq(hsh)
           end
         end
         context "which is a Metadata instance" do
           let(:data) { Metadata.new(hsh) }
-          it "should set the metadata to the hash" do
-            expect(subject).to eq(hsh)
+          it "should set the metadata elements to the hash" do
+            expect(subject.elements).to eq(hsh)
           end
         end
       end


### PR DESCRIPTION
The local metadata is cleared after persisting (create/mint or modify)
and reloaded only on subsequent access.

The `#metadata` reader method provides a boolean `refresh` parameter
(default: `true`) which can be used to bypass the reload. This may
be useful in testing scenarios.

Internal implementation details of Ezid::Metadata were also changed
without public API impact (the class itself is documented as
private).

Closes #23