### PR TITLE
Metadata element writer raises exception when value is not supported.

### DIFF
--- a/ezid-client.gemspec
+++ b/ezid-client.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 2.0"
 
-  spec.add_dependency "hashie"
+  spec.add_dependency "hashie", "~> 3.4", ">= 3.4.3"
 
   spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.1"
-  spec.add_development_dependency "rspec-its"
+  spec.add_development_dependency "rake", "~> 10.5"
+  spec.add_development_dependency "rspec", "~> 3.4"
+  spec.add_development_dependency "rspec-its", "~> 1.2"
 end

--- a/lib/ezid/metadata.rb
+++ b/lib/ezid/metadata.rb
@@ -54,14 +54,21 @@ module Ezid
       CREATED, DATACENTER, OWNER, OWNERGROUP, SHADOWEDBY, SHADOWS, UPDATED
     ].freeze
 
-    def initialize(data=nil)
+    # @param data [String, Hash, Ezid::Metadata] the initial data
+    # @param default [Object] DO NOT USE!
+    #   This param is included for compatibility with Hashie::Mash
+    #   and will raise a NotImplementedError if passed a non-nil value.
+    def initialize(data=nil, default=nil)
+      unless default.nil?
+        raise ::NotImplementedError, "ezid-client does not support default metadata values."
+      end
       super()
       update(data) if data
     end
 
     def elements
-      warn "[DEPRECATION] `elements` is deprecated and will be removed in ezid-client 2.0." \
-           " Use the Ezid::Metadata instance itself instead."
+      warn "[DEPRECATION] `Ezid::Metadata#elements` is deprecated and will be removed in ezid-client 2.0." \
+           " Use the `Ezid::Metadata` instance itself instead. (called from #{caller.first})"
       self
     end
 
@@ -110,6 +117,15 @@ module Ezid
       else
         converted
       end
+    end
+
+    # Overrides Hashie::Mash
+    def convert_value(value, duping=false)
+      if [self.class, Hash, Array].include?(value.class)
+        raise Error, "ezid-client does not support instances of #{value.class} as metadata values." \
+                     " Convert an enumerable such as an array to an appropriate string representation first."
+      end
+      value.to_s
     end
 
     private

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -1,11 +1,41 @@
 module Ezid
   RSpec.describe Metadata do
+    describe "initializer" do
+      it "raises an exception when called with a default value" do
+        expect { described_class.new(nil, 1) }.to raise_error(::NotImplementedError)
+      end
+    end
 
     describe "metadata accessors and aliases" do
       shared_examples "a metadata writer" do |writer|
+        let(:method) { "#{writer}=" }
         it "writes the \"#{writer}\" element" do
-          subject.send("#{writer}=", "value")
+          subject.send(method, "value")
           expect(subject[writer.to_s]).to eq("value")
+        end
+        describe "when the value is a Metadata instance" do
+          it "raises an exception" do
+            expect { subject.send(method, Metadata.new({foo: "value1", bar: "value2"})) }
+              .to raise_error(Error)
+          end
+        end
+        describe "when the value is a Hash" do
+          it "raises an exception" do
+            expect { subject.send(method, {foo: "value1", bar: "value2"}) }
+              .to raise_error(Error)
+          end
+        end
+        describe "when the value is an Array" do
+          it "raises an exception" do
+            expect { subject.send(method, ["value1", "value2"]) }
+              .to raise_error(Error)
+          end
+        end
+        describe "when the value is another type" do
+          it "coerces to a string" do
+            subject.send(method, 1)
+            expect(subject[writer.to_s]).to eq "1"
+          end
         end
       end
 
@@ -231,6 +261,5 @@ EOS
         end
       end
     end
-
   end
 end


### PR DESCRIPTION
Unsupported metadata values include Hash, Array, and Ezid::Metadata instances.
This is not a backward-incompatible change insofar as using them would trigger
unexpected errors (see #69) or not work as expected.

Although the API of Ezid::Metadata is marked private, it's worth noting
here that the initializer has been updated to be compatible with
superclass methods such as `#dup` that depend on the signature of
of the superclass initializer.