### PR TITLE
Ezid::BatchDownload#download_file returns file path (closes #73)

### DIFF
--- a/lib/ezid/batch_enumerator.rb
+++ b/lib/ezid/batch_enumerator.rb
@@ -1,0 +1,42 @@
+module Ezid
+  class BatchEnumerator
+    include Enumerable
+
+    attr_reader :format, :batch_file
+
+    def initialize(format, batch_file)
+      @format = format
+      @batch_file = batch_file
+    end
+
+    def each(&block)
+      case format
+      when :anvl
+        each_anvl &block
+      when :xml
+        each_xml &block
+      when :csv
+        each_csv &block
+      end
+    end
+
+    def each_anvl(&block)
+      File.open(batch_file, "rb") do |f|
+        while record = f.gets("")
+          head, metadata = record.split(/\n/, 2)
+          id = head.sub(/\A::/, "").strip
+          yield Ezid::Identifier.new(id, metadata: metadata)
+        end
+      end
+    end
+
+    def each_xml
+      raise NotImplementedError
+    end
+
+    def each_csv
+      raise NotImplementedError
+    end
+
+  end
+end

--- a/spec/fixtures/anvl_batch.txt
+++ b/spec/fixtures/anvl_batch.txt
@@ -1,0 +1,39 @@
+:: ark:/99999/fk4086hs23
+_updated: 1488227717
+_target: http://example.com
+_profile: erc
+_ownergroup: apitest
+_owner: apitest
+_export: yes
+_created: 1488227717
+_status: public
+
+:: ark:/99999/fk4086hs23/123
+_updated: 1488227718
+_target: http://ezid.cdlib.org/id/ark:/99999/fk4086hs23/123
+_profile: erc
+_ownergroup: apitest
+_owner: apitest
+_export: yes
+_created: 1488227718
+_status: public
+
+:: ark:/99999/fk40p1bb85
+_updated: 1488303565
+_target: http://ezid.cdlib.org/id/ark:/99999/fk40p1bb85
+_profile: erc
+_ownergroup: apitest
+_owner: apitest
+_export: yes
+_created: 1488303565
+_status: public
+
+:: ark:/99999/fk40z7fh7x
+_updated: 1488232856
+_target: http://ezid.cdlib.org/id/ark:/99999/fk40z7fh7x
+_profile: erc
+_ownergroup: apitest
+_owner: apitest
+_export: yes
+_created: 1488232856
+_status: public

--- a/spec/integration/batch_download_spec.rb
+++ b/spec/integration/batch_download_spec.rb
@@ -1,0 +1,21 @@
+require 'tempfile'
+
+module Ezid
+  RSpec.describe BatchDownload do
+
+    subject do
+      a_week_ago = (Time.now - (7*24*60*60)).to_i
+      described_class.new(:anvl, compression: "zip", permanence: "test", status: "public", createdAfter: a_week_ago)
+    end
+
+    its(:download_url) { is_expected.to match(/\Ahttp:\/\/ezid\.cdlib\.org\/download\/\w+\.zip\z/) }
+
+    specify {
+      Dir.mktmpdir do |tmpdir|
+        expect(subject.download_file(path: tmpdir))
+          .to match(/\A#{tmpdir}\/\w+\.zip\z/)
+      end
+    }
+
+  end
+end

--- a/spec/unit/batch_download_spec.rb
+++ b/spec/unit/batch_download_spec.rb
@@ -1,5 +1,0 @@
-module Ezid
-  RSpec.describe BatchDownload do
-    # TODO
-  end
-end

--- a/spec/unit/batch_enumerator_spec.rb
+++ b/spec/unit/batch_enumerator_spec.rb
@@ -1,0 +1,34 @@
+require 'ezid/batch_enumerator'
+
+module Ezid
+  RSpec.describe BatchEnumerator do
+
+    let(:batch_file) { File.expand_path("../../fixtures/anvl_batch.txt", __FILE__) }
+
+    subject { described_class.new(:anvl, batch_file) }
+
+    its(:count) { is_expected.to eq 4 }
+
+    specify {
+      subject.each do |id|
+        expect(id).to be_a(Identifier)
+      end
+    }
+
+    specify {
+      batch_array = subject.to_a
+      expect(batch_array.length).to eq 4
+    }
+
+    specify {
+      ids = subject.map(&:id)
+      expect(ids).to eq ["ark:/99999/fk4086hs23", "ark:/99999/fk4086hs23/123", "ark:/99999/fk40p1bb85", "ark:/99999/fk40z7fh7x"]
+    }
+
+    specify {
+      id = subject.first
+      expect(id.target).to eq "http://example.com"
+    }
+
+  end
+end


### PR DESCRIPTION
- Adds `compression` option to `Ezid::BatchDownload` (closes #74).
- Adds `Ezid::BatchEnumerator` to yield `Identifier` instances from
batch download file. Currently only supports ANVL format.