### PR TITLE
default to SSL

### DIFF
--- a/lib/ezid/configuration.rb
+++ b/lib/ezid/configuration.rb
@@ -44,7 +44,7 @@ module Ezid
       @password         = ENV["EZID_PASSWORD"]
       @host             = ENV["EZID_HOST"] || HOST
       @port             = ENV["EZID_PORT"] || PORT
-      @use_ssl          = true if ENV["EZID_USE_SSL"] == true.to_s
+      @use_ssl          = true unless ENV["EZID_USE_SSL"].casecmp("no")
       @timeout          = ENV["EZID_TIMEOUT"] || TIMEOUT
       @default_shoulder = ENV["EZID_DEFAULT_SHOULDER"]
     end


### PR DESCRIPTION
SSL should be the default after the 30th:
```
> From: EZID-L automatic digest system 
> Subject: EZID-L Digest - 11 Apr 2017 to 12 Apr 2017 (#2017-17)
> Date: April 13, 2017 at 12:02:36 AM PDT
[ 7 more citation lines. Click/Enter to hide. ]
> To: <EZID-L@LISTSERV.UCOP.EDU>
> 
> Date:    Wed, 12 Apr 2017 22:27:44 +0000
> From:    Joan Starr <Joan.Starr@UCOP.EDU>
> Subject: EZID will implement HTTPS on April 30, 2017
> 
> All,
> Thank you for your feedback. The overwhelming response was positive, so we plan to implement HTTPS on Sunday, April 30th. Please plan
> accordingly.
> --The EZID Team
```