### PR TITLE
Add datacite compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,11 +296,10 @@ require "ezid/test_helper"
 
 The module provides constants:
 
-- `TEST_ARK_SHOULDER` => "ark:/99999/fk4"
-- `TEST_DOI_SHOULDER` => "doi:10.5072/FK2"
-- `TEST_USER` => "apitest"
-- `TEST_HOST` => "ezid.cdlib.org"
-- `TEST_PORT` => 443
+- `EZID_TEST_SHOULDER` => "doi:10.5072/FK2"
+- `EZID_TEST_USER` => "apitest"
+- `EZID_TEST_HOST` => "ezid.cdlib.org"
+- `EZID_TEST_PORT` => 443
 
 The test user password is not provided - contact EZID and configure as above - or use your own EZID credentials, since all accounts can mint/create on the test shoulders.
 

--- a/ezid-client.gemspec
+++ b/ezid-client.gemspec
@@ -20,8 +20,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.1"
 
   spec.add_dependency "hashie", "~> 3.4", ">= 3.4.3"
+  spec.add_dependency "nokogiri"
 
   spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rspec-its", "~> 1.2"

--- a/lib/ezid/metadata_transforms/datacite.rb
+++ b/lib/ezid/metadata_transforms/datacite.rb
@@ -1,0 +1,63 @@
+require "nokogiri"
+
+module Ezid
+  class MetadataTransformDatacite
+
+    # Transforms the provided metadata hash into the appropriate format for datacite. Removes all "datacite.*" keys
+    # and transforms these to the appropriate datacite xml. The resultant xml is then added to a single "datacite" key.
+    def self.transform(hsh)
+      # Render the datacite xml
+      resource_opts = {
+        "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance",
+        "xmlns" => "http://datacite.org/schema/kernel-4",
+        "xsi:schemaLocation" => "http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd"
+      }
+      xml = Nokogiri::XML::Builder.new(encoding: "UTF-8") { |builder|
+        builder.resource(resource_opts) {
+          builder.identifier(identifierType: hsh["datacite.identifiertype"]) {
+            builder.text hsh["datacite.identifier"]
+          }
+          builder.creators {
+            builder.creator {
+              builder.creatorName hsh["datacite.creator"]
+            }
+          }
+          builder.titles {
+            builder.title hsh["datacite.title"]
+          }
+          builder.publisher hsh["datacite.publisher"]
+          builder.publicationYear hsh["datacite.publicationyear"]
+          builder.resourceType(resourceTypeGeneral: hsh["datacite.resourcetypegeneral"]) {
+            builder.text hsh["datacite.resourcetype"]
+          }
+          builder.descriptions {
+            builder.description(descriptionType: "Abstract") {
+              builder.text hsh["datacite.description"]
+            }
+          }
+        }
+      }.to_xml
+
+      # Transform the hash
+      hsh.reject! { |k, v| k =~ /^datacite\./ }
+      hsh["datacite"] = xml
+    end
+
+    # Transforms the provided datacite metadata hash into the format appropriate for the Metadata class.
+    # Extracts appropriate fields from the datacite xml and creates the corresponding "datacite.*" keys
+    def self.inverse(hsh)
+      xml = Nokogiri::XML(hsh["datacite"])
+      xmlns = "http://datacite.org/schema/kernel-4"
+      hsh["datacite.identifier"] = xml.at_xpath("/ns:resource/ns:identifier/text()", ns: xmlns).to_s
+      hsh["datacite.identifiertype"] = xml.at_xpath("/ns:resource/ns:identifier/attribute::identifierType", ns: xmlns).to_s
+      hsh["datacite.creator"] = xml.at_xpath("/ns:resource/ns:creators/ns:creator/ns:creatorName/text()", ns: xmlns).to_s
+      hsh["datacite.title"] = xml.at_xpath("/ns:resource/ns:titles/ns:title/text()", ns: xmlns).to_s
+      hsh["datacite.publisher"] = xml.at_xpath("/ns:resource/ns:publisher/text()", ns: xmlns).to_s
+      hsh["datacite.publicationyear"] = xml.at_xpath("/ns:resource/ns:publicationYear/text()", ns: xmlns).to_s
+      hsh["datacite.resourcetype"] = xml.at_xpath("/ns:resource/ns:resourceType/text()", ns: xmlns).to_s
+      hsh["datacite.resourcetypegeneral"] = xml.at_xpath("/ns:resource/ns:resourceType/attribute::resourceTypeGeneral", ns: xmlns).to_s
+      hsh["datacite.description"] = xml.at_xpath("/ns:resource/ns:descriptions/ns:description/text()", ns: xmlns).to_s
+      hsh.delete("datacite")
+    end
+  end
+end

--- a/spec/fixtures/datacite_xml/empty.xml
+++ b/spec/fixtures/datacite_xml/empty.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+  <identifier identifierType=""></identifier>
+  <creators>
+    <creator>
+      <creatorName/>
+    </creator>
+  </creators>
+  <titles>
+    <title/>
+  </titles>
+  <publisher/>
+  <publicationYear/>
+  <resourceType resourceTypeGeneral=""></resourceType>
+  <descriptions>
+    <description descriptionType="Abstract"></description>
+  </descriptions>
+</resource>

--- a/spec/fixtures/datacite_xml/populated.xml
+++ b/spec/fixtures/datacite_xml/populated.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+  <identifier identifierType="TestIdentifierType">TestIdentifier</identifier>
+  <creators>
+    <creator>
+      <creatorName>TestCreatorName</creatorName>
+    </creator>
+  </creators>
+  <titles>
+    <title>TestTitle</title>
+  </titles>
+  <publisher>TestPublisher</publisher>
+  <publicationYear>TestPublicationYear</publicationYear>
+  <resourceType resourceTypeGeneral="TestResourceTypeGeneral">TestResourceType</resourceType>
+  <descriptions>
+    <description descriptionType="Abstract">TestDescription</description>
+  </descriptions>
+</resource>

--- a/spec/unit/metadata_transform_datacite_spec.rb
+++ b/spec/unit/metadata_transform_datacite_spec.rb
@@ -1,0 +1,169 @@
+module Ezid
+  RSpec.describe MetadataTransformDatacite do
+    describe "#transform" do
+      before(:each) do
+        described_class.transform(test_hash)
+      end
+
+      context "when there are no datacite fields" do
+        let(:test_hash) { {} }
+        let(:expected_xml) { File.read("spec/fixtures/datacite_xml/empty.xml") }
+
+        it "populates a datacite xml field with all required fields as empty" do
+          expect(test_hash["datacite"]).to eq(expected_xml)
+        end
+      end
+
+      context "when there are datacite fields" do
+        let(:test_hash) { {
+          "datacite.identifier" => "TestIdentifier",
+          "datacite.identifiertype" => "TestIdentifierType",
+          "datacite.creator" => "TestCreatorName",
+          "datacite.title"   => "TestTitle",
+          "datacite.publisher" => "TestPublisher",
+          "datacite.publicationyear" => "TestPublicationYear",
+          "datacite.resourcetype" => "TestResourceType",
+          "datacite.resourcetypegeneral" => "TestResourceTypeGeneral",
+          "datacite.description" => "TestDescription",
+          "some.other.field" => "SomeOtherValue",
+        } }
+        let(:expected_xml) { File.read("spec/fixtures/datacite_xml/populated.xml") }
+
+        it "populates a datacite xml field using values from the datacite.* fields" do
+          expect(test_hash["datacite"]).to eq(expected_xml)
+        end
+
+        it "removes the datacite.* fields from the hash" do
+          expect(test_hash.keys).not_to include(
+            "datacite.identifer",
+            "datacite.identifiertype",
+            "datacite.creator",
+            "datacite.title",
+            "datacite.publisher",
+            "datacite.publicationyear",
+            "datacite.resourcetype",
+            "datacite.resourcetypegeneral",
+            "datacite.description",
+          )
+        end
+
+        it "does not remove other fields" do
+          expect(test_hash).to include("some.other.field")
+        end
+      end
+    end
+
+    describe "#inverse" do
+      let(:test_hash) { {
+        "datacite" => test_xml,
+        "some.other.field" => "SomeOtherValue"
+      } }
+
+      before(:each) do
+        described_class.inverse(test_hash)
+      end
+
+
+      context "when there are no datacite fields" do
+        let(:expected_hash) { {
+          "datacite.identifier" => "",
+          "datacite.identifiertype" => "",
+          "datacite.creator" => "",
+          "datacite.description" => "",
+          "datacite.publicationyear" => "",
+          "datacite.publisher" => "",
+          "datacite.resourcetype" => "",
+          "datacite.resourcetypegeneral" => "",
+          "datacite.title" => "",
+        } }
+        let(:test_xml) { File.read("spec/fixtures/datacite_xml/empty.xml") }
+
+        it "populates all required fields as empty" do
+          expect(test_hash).to include(expected_hash)
+        end
+      end
+
+      context "when there are datacite fields" do
+        let(:expected_hash) { {
+          "datacite.identifier" => "TestIdentifier",
+          "datacite.identifiertype" => "TestIdentifierType",
+          "datacite.creator" => "TestCreatorName",
+          "datacite.title"   => "TestTitle",
+          "datacite.publisher" => "TestPublisher",
+          "datacite.publicationyear" => "TestPublicationYear",
+          "datacite.resourcetype" => "TestResourceType",
+          "datacite.resourcetypegeneral" => "TestResourceTypeGeneral",
+          "datacite.description" => "TestDescription",
+        } }
+        let(:test_xml) { File.read("spec/fixtures/datacite_xml/populated.xml") }
+
+        it "populates all fields from the datacite.* fields" do
+          expect(test_hash).to include(expected_hash)
+        end
+
+        it "removes the datacite field" do
+          expect(test_hash).not_to include("datacite")
+        end
+
+        it "does not remove other fields" do
+          expect(test_hash).to include("some.other.field")
+        end
+      end
+    end
+
+    describe "#transform then #inverse" do
+      let(:test_hash) { {
+        "datacite.identifier" => "TestIdentifier",
+        "datacite.identifiertype" => "TestIdentifierType",
+        "datacite.creator" => "TestCreatorName",
+        "datacite.title"   => "TestTitle",
+        "datacite.publisher" => "TestPublisher",
+        "datacite.publicationyear" => "TestPublicationYear",
+        "datacite.resourcetype" => "TestResourceType",
+        "datacite.resourcetypegeneral" => "TestResourceTypeGeneral",
+        "datacite.description" => "TestDescription",
+        "some.other.field" => "SomeOtherValue",
+      } }
+
+      before(:each) do
+        described_class.transform(test_hash)
+        described_class.inverse(test_hash)
+      end
+
+      it "is a lossless transformation" do
+        expect(test_hash).to eq({
+          "datacite.identifier" => "TestIdentifier",
+          "datacite.identifiertype" => "TestIdentifierType",
+          "datacite.creator" => "TestCreatorName",
+          "datacite.title"   => "TestTitle",
+          "datacite.publisher" => "TestPublisher",
+          "datacite.publicationyear" => "TestPublicationYear",
+          "datacite.resourcetype" => "TestResourceType",
+          "datacite.resourcetypegeneral" => "TestResourceTypeGeneral",
+          "datacite.description" => "TestDescription",
+          "some.other.field" => "SomeOtherValue",
+        })
+      end
+    end
+
+    describe "#inverse then #transform" do
+      let(:test_xml) { File.read("spec/fixtures/datacite_xml/empty.xml") }
+      let(:test_hash) { {
+        "datacite" => test_xml,
+        "some.other.field" => "SomeOtherValue"
+      } }
+
+      before(:each) do
+        described_class.inverse(test_hash)
+        described_class.transform(test_hash)
+      end
+
+      it "is a lossless transformation" do
+        expect(test_hash).to eq({
+          "datacite" => test_xml,
+          "some.other.field" => "SomeOtherValue"
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Added a new MetadataTransformDatacite class that transforms a hashes datacite.* keys to the xml required by the datacite api.
- Added an additional step in Metdata#to_anvl. Before the metadata is converted to anvl, it will perform an additional transformation of the metadata hash to make it compatible with datacite. A future improvement might be to do IoC here so that we can inject requested transforms and ignore ones an app doesn't care about.
- Added an inverse transformation method for transforming metadata from the datacite api to keys required by the Metadata class
- Added an additional step in Metdata#replace to transform the remote datacite metadata into the correct format
- Also fixed some issues with the readme's testing env variables