### PR TITLE
Add datacite compatibility

### DIFF
--- a/lib/ezid/metadata_transforms/datacite.rb
+++ b/lib/ezid/metadata_transforms/datacite.rb
@@ -12,9 +12,9 @@ module Ezid
         "xmlns" => "http://datacite.org/schema/kernel-4",
         "xsi:schemaLocation" => "http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd"
       }
-      xml = Nokogiri::XML::Builder.new(encoding: "UTF-8") { |builder|
+      xml_builder = Nokogiri::XML::Builder.new(encoding: "UTF-8") { |builder|
         builder.resource(resource_opts) {
-          builder.identifier(identifierType: hsh["datacite.identifiertype"]) {
+          builder.identifier(identifierType: hsh["datacite.identifiertype"] || "DOI") {
             builder.text hsh["datacite.identifier"]
           }
           builder.creators {
@@ -36,7 +36,16 @@ module Ezid
             }
           }
         }
-      }.to_xml
+      }
+      # Using this save option to prevent NG from rendering new lines and tabs
+      # between nodes. This to help with a cleaner anvl conversion. Similarly,
+      # the sub should just remove the new line after the xml header that NG
+      # adds, ex:
+      #   <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<resource ...
+      xml = xml_builder
+        .to_xml(save_with: Nokogiri::XML::Node::SaveOptions::AS_XML)
+        .sub("\n", "")
+
 
       # Transform the hash
       hsh.reject! { |k, v| k =~ /^datacite\./ }

--- a/spec/fixtures/datacite_xml/empty.xml
+++ b/spec/fixtures/datacite_xml/empty.xml
@@ -1,18 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
-  <identifier identifierType=""></identifier>
-  <creators>
-    <creator>
-      <creatorName/>
-    </creator>
-  </creators>
-  <titles>
-    <title/>
-  </titles>
-  <publisher/>
-  <publicationYear/>
-  <resourceType resourceTypeGeneral=""></resourceType>
-  <descriptions>
-    <description descriptionType="Abstract"></description>
-  </descriptions>
-</resource>
+<?xml version="1.0" encoding="UTF-8"?><resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd"><identifier identifierType="DOI"></identifier><creators><creator><creatorName/></creator></creators><titles><title/></titles><publisher/><publicationYear/><resourceType resourceTypeGeneral=""></resourceType><descriptions><description descriptionType="Abstract"></description></descriptions></resource>

--- a/spec/fixtures/datacite_xml/populated.xml
+++ b/spec/fixtures/datacite_xml/populated.xml
@@ -1,18 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
-  <identifier identifierType="TestIdentifierType">TestIdentifier</identifier>
-  <creators>
-    <creator>
-      <creatorName>TestCreatorName</creatorName>
-    </creator>
-  </creators>
-  <titles>
-    <title>TestTitle</title>
-  </titles>
-  <publisher>TestPublisher</publisher>
-  <publicationYear>TestPublicationYear</publicationYear>
-  <resourceType resourceTypeGeneral="TestResourceTypeGeneral">TestResourceType</resourceType>
-  <descriptions>
-    <description descriptionType="Abstract">TestDescription</description>
-  </descriptions>
-</resource>
+<?xml version="1.0" encoding="UTF-8"?><resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd"><identifier identifierType="TestIdentifierType">TestIdentifier</identifier><creators><creator><creatorName>TestCreatorName</creatorName></creator></creators><titles><title>TestTitle</title></titles><publisher>TestPublisher</publisher><publicationYear>TestPublicationYear</publicationYear><resourceType resourceTypeGeneral="TestResourceTypeGeneral">TestResourceType</resourceType><descriptions><description descriptionType="Abstract">TestDescription</description></descriptions></resource>

--- a/spec/unit/metadata_transform_datacite_spec.rb
+++ b/spec/unit/metadata_transform_datacite_spec.rb
@@ -67,7 +67,7 @@ module Ezid
       context "when there are no datacite fields" do
         let(:expected_hash) { {
           "datacite.identifier" => "",
-          "datacite.identifiertype" => "",
+          "datacite.identifiertype" => "DOI",
           "datacite.creator" => "",
           "datacite.description" => "",
           "datacite.publicationyear" => "",


### PR DESCRIPTION
A few additional changes are needed to support the Datacite EZAPI:

- Added a default DOI identifier type even when one is not available in the existing metadata. I've found that if you add this, the api's will generate the identifier xml for you. This is mostly for the case when you want to mint and give it the metadata in one op, since you won't have the identifier yet.
- Datacite chokes on newlines in the xml. Likely to do with how the anvl gets parsed. Changed the transform to remove all new lines from the xml and fixed specs/fixtures to match.