### PR TITLE
Allow ruby version 3

### DIFF
--- a/ezid-client.gemspec
+++ b/ezid-client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.1"
+  spec.required_ruby_version = ">= 2"
 
   spec.add_dependency "hashie", "~> 3.4", ">= 3.4.3"
   spec.add_dependency "nokogiri"

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -74,7 +74,7 @@ module Ezid
       it "should return a valid URL" do
         response = subject.batch_download(format: "anvl", createdAfter: @created, permanence: "test")
         expect(response).to be_success
-        expect(response.download_url).to match(/^http:\/\/ezid.cdlib.org\/download\/[^\/]+.gz$/)
+        expect(response.download_url).to match(/^https?:\/\/ezid.cdlib.org\/download\/[^\/]+.gz$/)
       end
     end
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -162,11 +162,11 @@ EOS
       let(:body) { "success: http://ezid.cdlib.org/download/da543b91a0.xml.gz" }
 
       before do
-        allow(BatchDownloadRequest).to receive(:execute).with(subject, format: "xml") { stub_response }
+        allow(BatchDownloadRequest).to receive(:execute).with(subject, {format: "xml"}) { stub_response }
       end
 
       it "returns the URL to download the batch" do
-        response = subject.batch_download(format: "xml")
+        response = subject.batch_download({format: "xml"})
         expect(response).to be_success
         expect(response.download_url).to eq("http://ezid.cdlib.org/download/da543b91a0.xml.gz")
       end

--- a/spec/unit/identifier_spec.rb
+++ b/spec/unit/identifier_spec.rb
@@ -49,7 +49,7 @@ _status: public
         end
         describe "with a hash metadata arg", deprecated: true do
           it "mints a new Identifier" do
-            expect(described_class).to receive(:mint).with(nil, profile: "dc", target: "http://example.com")
+            expect(described_class).to receive(:mint).with(nil, {profile: "dc", target: "http://example.com"})
             described_class.create(profile: "dc", target: "http://example.com")
           end
         end


### PR DESCRIPTION
We're using the EZID client gem for Data Dryad (https://github.com/CDL-Dryad/dryad-app), which is in the process of a ruby and rails upgrade. The EZID client gem requiring ruby versions 2.x and no higher is a blocker for us.